### PR TITLE
override forward sender

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies gmime
-      run: sudo apt-get install libgmime-3.0-dev libmhash-dev libssl-dev  libevent-dev libzdb-dev
+      run: sudo apt-get install libgmime-3.0-dev libmhash-dev libssl-dev  libevent-dev libzdb-dev libcurl4-gnutls-dev
 
     - name: configure
       run: ./configure

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -85,6 +85,17 @@ sendmail              = /usr/sbin/sendmail
 # smtp_user
 # smtp_password
 
+# 
+# Allows to override sender when forwards are made (based dbmail_alias table)
+# Works for both authsql and authldap.
+# Bounces are never forwarded in order to prevent denial of service
+#
+# 0 = no forward override, it preserves the original sender.
+# 1 = all forwards have the sender changed to the actual alias
+# 2 = allows a finner degree of control by specifing which aliases can have their sender changed or not. When using authldap, 
+#		the control is based on information written in dbmail_alias table, by switching on/off the override_fw_sender
+#
+forward_sender_override	   = 0
 #
 #
 # The following items can be overridden in the service-specific sections.

--- a/sql/mysql/upgrades/35001.mysql
+++ b/sql/mysql/upgrades/35001.mysql
@@ -26,6 +26,8 @@ ALTER TABLE `dbmail_usermap` CONVERT TO CHARACTER SET utf8mb4;
 ALTER TABLE `dbmail_users` CONVERT TO CHARACTER SET utf8mb4;
 
 ALTER TABLE `dbmail_physmessage` ADD COLUMN `messagetype` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0';
+ALTER TABLE `dbmail_aliases` ADD COLUMN `override_fw_sender` int UNSIGNED NOT NULL DEFAULT '0';
+
 
 INSERT INTO dbmail_upgrade_steps (from_version, to_version, applied) values (32006, 35001, now());
 

--- a/sql/postgresql/upgrades/35001.psql
+++ b/sql/postgresql/upgrades/35001.psql
@@ -1,6 +1,8 @@
 BEGIN;
 
 ALTER TABLE `dbmail_physmessage` ADD COLUMN `messagetype` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0';
+ALTER TABLE `dbmail_aliases` ADD COLUMN `override_fw_sender` int UNSIGNED NOT NULL DEFAULT '0';
+
 -- noop as mysql upgrade only
 INSERT INTO dbmail_upgrade_steps (from_version, to_version) values (32006, 35001);
 

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -163,7 +163,8 @@ typedef struct {
 	int part_key;
 	int part_depth;
 	int part_order;
-	//if the message is of types or contains in it's body the following
+	
+	//flag: nessages that contain certain types of parts
 	//- message/delivery-status
 	//- multipart/report
 	//0 = normal, 1 = delivery report

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -252,8 +252,8 @@ int config_get_value_default_int(const Field_T field_name,
 					int default_value){
 	Field_T value;
 	int result_fetch = config_get_value(field_name, service_name, value);
-	int result=default_value;
-	if (result_fetch==0){
+	int result = default_value;
+	if (result_fetch == 0){
 		/* no error */
 		result=atoi(value);
 	}

--- a/src/dm_db.h
+++ b/src/dm_db.h
@@ -228,7 +228,10 @@ void mailbox_match_free(struct mailbox_match *m);
  * -  1 on table found
  */
 int db_use_usermap(void);
-
+/**
+ * Check if we can perform forward sender override
+ */
+int dm_check_forward_override(const char *from, const char *to);
 /**
  * \brief check if username exists in the usermap table
  * \param int tx filehandle of connected client

--- a/src/dm_dsn.c
+++ b/src/dm_dsn.c
@@ -217,6 +217,11 @@ void dsnuser_free(Delivery_T * dsnuser)
 	if (dsnuser->forwards) {
 		dsnuser->forwards = g_list_first(dsnuser->forwards);
 		while(dsnuser->forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)(dsnuser->forwards->data);
+			g_free(pair->from);
+			pair->from = NULL;
+			g_free(pair->to);
+			pair->to = NULL;
 			g_free(dsnuser->forwards->data);
 			dsnuser->forwards = g_list_next(dsnuser->forwards);
 		}

--- a/src/dm_dsn.h
+++ b/src/dm_dsn.h
@@ -39,13 +39,20 @@ typedef struct {
 	int detail;
 } delivery_status_t;
 
+//structure of the forward override sender
+typedef struct {
+	char *from;
+	char *to;
+	uint64_t override_fw_sender;
+} DeliveryItem_T;
+
 typedef struct {
 	uint64_t useridnr;		/* Specific user id recipient (from outside). */
 	char *address;	/* Envelope recipient (from outside). */
 	char *mailbox;	/* Default mailbox to use for userid deliveries (from outside). */
 	mailbox_source source; /* Who specified the mailbox (e.g. trusted or untrusted source)? */
 	GList *userids;	/* List of uint64_t* -- internal useridnr's to deliver to (internal). */
-	GList *forwards;	/* List of char* -- external addresses to forward to (internal). */
+	GList *forwards;	/* List of DeliveryItem_T -- external addresses to forward to (internal). */
 	delivery_status_t dsn;	/* Return status of this "delivery basket" (to outside). */
 } Delivery_T;
 

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -2955,7 +2955,12 @@ int send_forward_list(DbmailMessage *message, GList *targets, const char *from)
 	targets = g_list_first(targets);
 	TRACE(TRACE_INFO, "delivering to [%u] external addresses", g_list_length(targets));
 	while (targets) {
-		char *to = (char *)targets->data;
+
+		//char *to = (char *)targets->data;
+		DeliveryItem_T *pair = (DeliveryItem_T *)targets->data;
+		char *from_local=g_strdup(pair->from);
+		char *to=g_strdup(pair->to);
+
 
 		if (!to || strlen(to) < 1) {
 			TRACE(TRACE_ERR, "forwarding address is zero length, message not forwarded.");
@@ -2983,8 +2988,25 @@ int send_forward_list(DbmailMessage *message, GList *targets, const char *from)
 				// The forward is a command to execute.
 				result |= send_mail(message, "", "", NULL, SENDRAW, to+1);
 			} else {
-				// The forward is an email address.
-				result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
+				if (message->message_type == 0){
+					//this is a normal message(not a bounce), evaluate the need to change from source
+					if (dm_check_forward_override(from_local,to)>0){
+						if (from_local){
+							TRACE(TRACE_ERR, "forwarding normal message by changing %s to %s", from, from_local);
+							result |= send_mail(message, to, from_local, NULL, SENDRAW, SENDMAIL);
+						}else{
+							TRACE(TRACE_ERR, "forwarding normal message to default from %s due to null from", from);
+							result |= send_mail(message, to, from_local, NULL, SENDRAW, SENDMAIL);
+						}
+					}else{
+						TRACE(TRACE_ERR, "forwarding normal message to %s, not changing to %s", from, from_local);
+						result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
+					}
+				}else{
+					// The forward is an email address.
+					TRACE(TRACE_ERR, "forwarding bounce message to %s,  not changing to %s", from, from_local);
+					result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
+				}
 			}
 		}
 		if (! g_list_next(targets))
@@ -3145,7 +3167,7 @@ int insert_messages(DbmailMessage *message, List_T dsnusers)
 		/* Each user may also have a list of external forwarding addresses. */
 		if (g_list_length(delivery->forwards) > 0) {
 			TRACE(TRACE_DEBUG, "delivering to external addresses");
-			const char *from = dbmail_message_get_header(message, "Return-Path");
+			const char *from = g_strdup(dbmail_message_get_header(message, "Return-Path"));
 			/* Forward using the temporary stored message. */
 			if (send_forward_list(message, delivery->forwards, from)) {
 				/* If forward fails, tell the sender that we're

--- a/src/dm_user.c
+++ b/src/dm_user.c
@@ -680,16 +680,40 @@ static int show_alias(const char * const name, int concise)
 	}
 
 	if (forwards) {
+		GList *fwd=NULL;
+		while (forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)forwards->data;
+			//char *from_local=pair->from;
+			char *to=g_strdup(pair->to);
+			fwd = g_list_prepend(fwd, to);
+			if (! g_list_next(forwards))
+				break;
+			forwards = g_list_next(forwards);
+		}
+		GString *fwdlist = g_list_join(fwd,",");
 		if (concise) {
-			GString *fwdlist = g_list_join(forwards,",");
+			//GString *fwdlist = g_list_join(forwards,",");
 			printf("%s: %s\n", name, fwdlist->str);
-			g_string_free(fwdlist, TRUE);
+			//g_string_free(fwdlist, TRUE);
 		} else {
-			GString *fwdlist = g_list_join(forwards,", ");
+			//GString *fwdlist = g_list_join(forwards,", ");
 			printf("forward [%s] to [%s]\n", name, fwdlist->str);
-			g_string_free(fwdlist, TRUE);
+			//g_string_free(fwdlist, TRUE);
+		}
+		g_string_free(fwdlist, TRUE);
+
+		while(forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)(forwards)->data;
+			g_free(pair->from);
+			pair->from = NULL;
+			g_free(pair->to);
+			pair->to = NULL;
+			if (! g_list_next(forwards)) break;
+			forwards = g_list_next(forwards);
 		}
 		g_list_destroy(g_list_first(forwards));
+		//g_list_destroy(g_list_first(forwards));
+		g_list_destroy(fwd);
 	}
 	
 	userids = g_list_first(userids);

--- a/src/modules/authsql.c
+++ b/src/modules/authsql.c
@@ -227,8 +227,9 @@ int auth_check_user_ext(const char *username, GList **userids, GList **fwds, int
 				TRACE(TRACE_DEBUG, "user [%s] is not active", username);
 			}
 		} else {
-			*(GList **)fwds = g_list_prepend(*(GList **)fwds, g_strdup(username));
-			TRACE(TRACE_DEBUG, "adding [%s] to deliver_to address occurences [%d]", username, occurences);
+			//do not do anything
+			//*(GList **)fwds = g_list_prepend(*(GList **)fwds, g_strdup(username));
+			//TRACE(TRACE_DEBUG, "adding [%s] to deliver_to address occurences [%d]", username, occurences);
 		}
 		return occurences;
 	} 
@@ -237,9 +238,18 @@ int auth_check_user_ext(const char *username, GList **userids, GList **fwds, int
 		/* do a recursive search for deliver_to */
 		char *deliver_to = (char *)d->data;
 		TRACE(TRACE_DEBUG, "checking user %s to %s", username, deliver_to);
-		
 		occurences += auth_check_user_ext(deliver_to, userids, fwds, checks+1);
-
+		TRACE(TRACE_DEBUG, "checking(2) user %s to %s", username, deliver_to);
+		id = strtoull(deliver_to, &endptr, 10);
+		if (id == 0) {
+			//add only is not an integer (which is actually a mailbox)
+			DeliveryItem_T *item = g_new0(DeliveryItem_T,1);
+			TRACE(TRACE_DEBUG, "adding [%s] to deliver_to %s, occurences [%d]", username, deliver_to, occurences);
+			//should add to fwds
+			item->from = g_strdup(username);
+			item->to = g_strdup(deliver_to);
+			*(GList **)fwds = g_list_prepend(*(GList **)fwds, item);
+		}
 		if (! g_list_next(d)) break;
 		d = g_list_next(d);
 	}


### PR DESCRIPTION
In some cases there is a need to change the sender of the message to comply with SPF and DKIM. It is useful when your sever doesn't have SRS enabled (or not available). When forwards are made to it's tagets, the message keeps the original sender, thus breakinng SPF and DKIM (in some cases). This feature allows to change the actual sender of the message sent to the forwarding targets to the actual forwarding(alias) address.
- dbmail.conf configuration, the feature is off by default, see forward_sender_override
- handles bounces by analyzing the type of message received (multipart/report, contains delivery-status parts). In order to prevent DOS, forwarding are not enabled for this type of messages.